### PR TITLE
Taskをフロントに表示させる

### DIFF
--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -13,6 +13,9 @@
         <button @click="createTask">タスク作成</button>
         <br>
         <span class="header-item" @click="logout">ログアウト</span>
+        <div class="registered-tasks">
+            <h4>登録されているタスク</h4>
+        </div>
     </div>
 </template>
 
@@ -49,5 +52,11 @@ export default {
 <style scoped>
 .header-item {
     cursor: pointer;
+}
+
+.registered-tasks {
+    position: relative;
+    bottom: 200px;
+    left: 300px;
 }
 </style>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -15,6 +15,11 @@
         <span class="header-item" @click="logout">ログアウト</span>
         <div class="registered-tasks">
             <h4>登録されているタスク</h4>
+            <ul>
+                <li v-for="data in taskLists">
+                    名前: {{data.name}} 詳細: {{data.description}}
+                </li>
+            </ul>
         </div>
     </div>
 </template>
@@ -27,12 +32,13 @@ export default {
         return {
             taskName: "",
             description: "",
-            taskList: [],
+            taskLists: [],
         };
     },
     created() {
         axios.get('http://localhost:3000/v1/auth/tasks')
         .then(response => {
+            this.taskLists = response.data
             console.log(response);
         })
     },

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -27,6 +27,7 @@ export default {
         return {
             taskName: "",
             description: "",
+            taskList: [],
         };
     },
     methods: {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -30,6 +30,12 @@ export default {
             taskList: [],
         };
     },
+    created() {
+        axios.get('http://localhost:3000/v1/auth/tasks')
+        .then(response => {
+            console.log(response);
+        })
+    },
     methods: {
         logout() {
             // store/index.jsのlogout関数を実行させるようにする

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -35,7 +35,7 @@ export default {
             axios.post('http://localhost:3000/v1/auth/tasks',{
                 task_params:
                 {
-                    taskName: this.taskName,
+                    name: this.taskName,
                     description: this.description
                 }
             })


### PR DESCRIPTION
ログインユーザーのタスクをフロントに表示させることはできたが、新たな問題としてログイン直後だとタスクが読み込まれていないように見えるので、この部分を改善する。